### PR TITLE
Do not use hardcoded user id for bot user

### DIFF
--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -964,10 +964,13 @@ class crawler {
                                                  FROM {logstore_standard_log} log
                                                 WHERE log.timecreated > :startingtime
                                                 AND target = 'course'
-                                                AND userid <> '19156'
+                                                AND userid NOT IN (
+                                                    SELECT id FROM {user} WHERE username = :botusername
+                                                )
                                                 AND courseid <> 1
                                             ";
-        $values = ['startingtime' => $startingtimerecentactivity];
+        $botusername = isset($config->botusername) ? $config->botusername : '';
+        $values = ['startingtime' => $startingtimerecentactivity, 'botusername' => $botusername];
 
         $rs = $DB->get_recordset_sql($sql, $values);
         $recentcourses = [];


### PR DESCRIPTION
Also work around potentially uninitialized use of object field. Can
happen before first configuration.

If the bot user name has not yet been configured, internally use an
empty bot user name for the SQL subquery in order to get an empty return
set (as there are no users with empty user name). The modified outer SQL
query therefore ignores an unconfigured (or mistyped) bot user name, and
will of course also behave as intended when the bot user name has been
configured.

Fixes #53.