### PR TITLE
Modernize dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,35 +6,43 @@ cache:
     - $HOME/.npm
 
 php:
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 sudo: required
 
 addons:
   firefox: "35.0.1"
-  postgresql: "9.3"
+  postgresql: "9.4"
   apt:
     packages:
       - oracle-java8-installer
       - oracle-java8-set-default
 
 env:
-  - DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_32_STABLE CI_PLUGIN=2
-  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE CI_PLUGIN=2
-  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE CI_PLUGIN=2
-  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE CI_PLUGIN=2
+  - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE CI_PLUGIN=2
+  - DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE CI_PLUGIN=2
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_27_STABLE
-    - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_28_STABLE
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_29_STABLE
     - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE CI_PLUGIN=2
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE CI_PLUGIN=2
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE CI_PLUGIN=2
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE CI_PLUGIN=2
+    - php: 7.2
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE CI_PLUGIN=2
+    - php: 7.2
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE CI_PLUGIN=2
+    - php: 7.2
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE CI_PLUGIN=2
+    - php: 7.2
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE CI_PLUGIN=2
+    - php: 7.3
       env: DB=mysqli MOODLE_BRANCH=master CI_PLUGIN=2
 
 before_install:
@@ -42,8 +50,8 @@ before_install:
   - phpenv config-rm xdebug.ini
   - cd ../..
   - if [ "$CI_PLUGIN" = 2 ]; then
-      nvm install node;
-      nvm use 8.9;
+      nvm install 8;
+      nvm use 8;
       composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2;
     else
       composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1;

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2018070200;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->release   = 2018070200;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->requires  = 2013110500;        // Requires this Moodle version.
+$plugin->requires  = 2016021800;        // Requires this Moodle version.
 $plugin->component = 'tool_crawler'; // To check on upgrade, that module sits in correct place.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->dependencies = array(


### PR DESCRIPTION
While working on the crawler code for our own needs, we needed the ability to have Travis test the code automatically without erroring out all the time. So we have developed this code which ensures that the dependencies of the plugins are brought up to date, and testing works smoothly again. This fixes #55 (but is a bit more invasive). Hope you like it. :-)